### PR TITLE
Added new Skyblock News Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This directory contains all the example code for this library. Each component ha
 ├── LICENSE            # None set yet
 ├── README.md          # This file
 ├── .gitignore         # Files to ignore during our git process
-├── .env               # File to store environment vairables such as API keys for examples.
+├── .env               # (Will be gitignored) File to store environment vairables such as API keys for examples.
 ├── Makefile           # Commands for building, initializing, and other tasks
 ├── requirements.txt   # Lists the Python package dependencies
 ├── setup.py           # Setup script for packaging and distribution

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This directory contains all the example code for this library. Each component ha
 ├── LICENSE            # None set yet
 ├── README.md          # This file
 ├── .gitignore         # Files to ignore during our git process
+├── .env               # File to store environment vairables such as API keys for examples.
 ├── Makefile           # Commands for building, initializing, and other tasks
 ├── requirements.txt   # Lists the Python package dependencies
 ├── setup.py           # Setup script for packaging and distribution

--- a/examples/news_example.py
+++ b/examples/news_example.py
@@ -1,0 +1,43 @@
+from hypixel_api_lib.News import SkyBlockNews 
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+try:
+    skyblock_news = SkyBlockNews(api_key=os.getenv("HYPIXEL_API_KEY"))
+except PermissionError as e:
+    print(f"Permission error: {e}")
+    exit()
+except ConnectionError as e:
+    print(f"Connection error: {e}")
+    exit()
+
+# Latest news
+latest_news = skyblock_news.get_latest_news()
+if latest_news:
+    print("Latest News:")
+    print(f"Title: {latest_news.title}")
+    print(f"Date: {latest_news.date_str}")
+    print(f"Material: {latest_news.material}")
+    print(f"Link: {latest_news.link}")
+else:
+    print("No news available.")
+
+# Get all news items
+all_news = skyblock_news.get_all_news()
+print(f"\nTotal News Items: {len(all_news)}")
+for news_item in all_news:
+    date_display = news_item.date.strftime('%d %B %Y') if news_item.date else news_item.date_str
+    print(f"- {news_item.title} ({date_display})")
+
+
+# Get news by specific date
+from datetime import date
+
+specific_date = date(2024, 10, 15)
+news_on_date = skyblock_news.get_news_by_date(specific_date)
+
+print(f"\nNews items on {specific_date.strftime('%d %B %Y')}:")
+for news_item in news_on_date:
+    print(f"- {news_item.title}")

--- a/hypixel_api_lib/News.py
+++ b/hypixel_api_lib/News.py
@@ -1,0 +1,134 @@
+import requests
+import re
+from datetime import datetime
+
+NEWS_API_URL = "https://api.hypixel.net/skyblock/news"
+
+class SkyBlockNewsItem:
+    """
+    Represents a news item in SkyBlock.
+
+    Attributes:
+        material (str): The material associated with the news item (e.g., 'GOLD_BLOCK').
+        link (str): The URL link to the full news article.
+        date (datetime): The date of the news item.
+        title (str): The title of the news item.
+    """
+
+    def __init__(self, material, link, date_str, title):
+        self.material = material
+        self.link = link
+        self.date_str = date_str
+        self.date = self._parse_date(date_str)
+        self.title = title
+
+    def _parse_date(self, date_str):
+        """Parse the date string into a datetime object."""
+        try:
+            date_str_clean = re.sub(r'(\d{1,2})(?:st|nd|rd|th)', r'\1', date_str)
+            return datetime.strptime(date_str_clean, '%d %B %Y')
+        except ValueError as e:
+            print(f"Date parsing error for '{date_str}': {e}")
+            return None
+
+    def __str__(self):
+        date_display = self.date.strftime('%d %B %Y') if self.date else self.date_str
+        return f"{self.title} ({date_display})"
+
+class SkyBlockNews:
+    """
+    Handles fetching and managing all the news items from the API.
+
+    Attributes:
+        api_endpoint (str): The endpoint URL to fetch the news data.
+        api_key (str): The API key required for the request.
+        news_items (list of SkyBlockNewsItem): A list of SkyBlockNewsItem objects.
+    """
+
+    def __init__(self, api_key, api_endpoint=NEWS_API_URL):
+        self.api_endpoint = api_endpoint
+        self.api_key = api_key
+        self.news_items = []
+        self._load_news()
+
+    def _load_news(self):
+        """Fetch news data from the API and initialize SkyBlockNewsItem objects."""
+        try:
+            params = {'key': self.api_key}
+            response = requests.get(self.api_endpoint, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            if data.get("success") and "items" in data and data["items"]:
+                self.news_items = []
+                for news_data in data["items"]:
+                    material_data = news_data.get('item', {})
+                    material = material_data.get('material')
+
+                    news_item = SkyBlockNewsItem(
+                        material=material,
+                        link=news_data.get('link'),
+                        date_str=news_data.get('text'),
+                        title=news_data.get('title'),
+                    )
+                    self.news_items.append(news_item)
+            else:
+                raise ValueError("No news data available in the response")
+        except requests.exceptions.HTTPError as e:
+            response_status = response.status_code
+            if response_status == 403:
+                raise PermissionError("Access forbidden: Invalid API key.")
+            elif response_status == 429:
+                raise ConnectionError("Request limit reached: Throttling in effect.")
+            else:
+                raise ConnectionError(f"HTTP error occurred: {e}")
+        except requests.exceptions.RequestException as e:
+            raise ConnectionError(f"An error occurred while fetching news: {e}")
+
+    def get_latest_news(self):
+        """
+        Retrieve the latest news item.
+
+        Returns:
+            SkyBlockNewsItem or None: The latest SkyBlockNewsItem object, or None if no news is available.
+        """
+        return self.news_items[0] if self.news_items else None
+
+    def get_all_news(self):
+        """
+        Retrieve all news items.
+
+        Returns:
+            list of SkyBlockNewsItem: A list of all SkyBlockNewsItem objects.
+        """
+        return self.news_items
+
+    def search_news_by_title(self, keyword):
+        """
+        Search news items by a keyword in their title.
+
+        Args:
+            keyword (str): The keyword to search for in the news titles.
+
+        Returns:
+            list of SkyBlockNewsItem: A list of news items that contain the keyword in their title.
+        """
+        return [
+            news_item for news_item in self.news_items
+            if keyword.lower() in news_item.title.lower()
+        ]
+
+    def get_news_by_date(self, date):
+        """
+        Retrieve news items for a specific date.
+
+        Args:
+            date (datetime.date): The date to filter news items by.
+
+        Returns:
+            list of SkyBlockNewsItem: A list of news items published on the specified date.
+        """
+        return [
+            news_item for news_item in self.news_items
+            if news_item.date and news_item.date.date() == date
+        ]

--- a/hypixel_api_lib/News.py
+++ b/hypixel_api_lib/News.py
@@ -81,7 +81,7 @@ class SkyBlockNews:
             elif response_status == 429:
                 raise ConnectionError("Request limit reached: Throttling in effect.")
             else:
-                raise ConnectionError(f"HTTP error occurred: {e}")
+                raise ConnectionError(f"An error occurred while fetching news: {e}")
         except requests.exceptions.RequestException as e:
             raise ConnectionError(f"An error occurred while fetching news: {e}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests==2.32.3
 numpy==2.1.2
 pandas==2.2.3
+python-dotenv
 wheel
 setuptools
 twine

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,286 @@
+import unittest
+from unittest.mock import patch
+import requests
+from datetime import date
+
+from hypixel_api_lib.News import SkyBlockNews, SkyBlockNewsItem
+
+class TestSkyBlockNews(unittest.TestCase):
+    def setUp(self):
+        # Sample data to mimic the API response
+        self.sample_api_response = {
+            "success": True,
+            "items": [
+                {
+                    "item": {"material": "GOLD_BLOCK"},
+                    "link": "https://hypixel.net/threads/5783275/",
+                    "text": "15th October 2024",
+                    "title": "SkyBlock v0.20.7"
+                },
+                {
+                    "item": {"material": "DIAMOND_PICKAXE"},
+                    "link": "https://hypixel.net/threads/5763578/",
+                    "text": "17th September 2024",
+                    "title": "SkyBlock v0.20.6"
+                },
+                {
+                    "item": {"material": "INK_SACK"},
+                    "link": "https://hypixel.net/threads/5738722/",
+                    "text": "6th August 2024",
+                    "title": "SkyBlock v0.20.5"
+                },
+                {
+                    "item": {"material": "RAW_BEEF"},
+                    "link": "https://hypixel.net/threads/5713272/",
+                    "text": "9th July 2024",
+                    "title": "SkyBlock v0.20.4"
+                },
+                {
+                    "item": {"material": "JUKEBOX"},
+                    "link": "https://hypixel.net/threads/5692280/",
+                    "text": "2nd July 2024",
+                    "title": "SkyBlock v0.20.3"
+                },
+                {
+                    "item": {"material": "RABBIT_HIDE"},
+                    "link": "https://hypixel.net/threads/5673834/",
+                    "text": "28th May 2024",
+                    "title": "SkyBlock v0.20.2"
+                },
+                {
+                    "item": {"material": "RABBIT_FOOT"},
+                    "link": "https://hypixel.net/threads/5645591/",
+                    "text": "24th April 2024",
+                    "title": "SkyBlock v0.20.1"
+                }
+            ]
+        }
+        self.dummy_api_key = 'DUMMY_API_KEY'
+
+    @patch('requests.get')
+    def test_load_news(self, mock_get):
+        """
+        Test that news items are loaded correctly from the API.
+        """
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.sample_api_response
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        self.assertIsNotNone(news_manager.news_items)
+        self.assertEqual(len(news_manager.news_items), 7)
+        self.assertEqual(news_manager.news_items[0].title, "SkyBlock v0.20.7")
+        self.assertEqual(news_manager.news_items[0].material, "GOLD_BLOCK")
+
+    @patch('requests.get')
+    def test_get_latest_news(self, mock_get):
+        """
+        Test retrieving the latest news item.
+        """
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.sample_api_response
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        latest_news = news_manager.get_latest_news()
+        self.assertIsNotNone(latest_news)
+        self.assertIsInstance(latest_news, SkyBlockNewsItem)
+        self.assertEqual(latest_news.title, "SkyBlock v0.20.7")
+        self.assertEqual(latest_news.link, "https://hypixel.net/threads/5783275/")
+
+    @patch('requests.get')
+    def test_get_all_news(self, mock_get):
+        """
+        Test retrieving all news items.
+        """
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.sample_api_response
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        all_news = news_manager.get_all_news()
+        self.assertEqual(len(all_news), 7)
+        titles = [news_item.title for news_item in all_news]
+        expected_titles = [
+            "SkyBlock v0.20.7",
+            "SkyBlock v0.20.6",
+            "SkyBlock v0.20.5",
+            "SkyBlock v0.20.4",
+            "SkyBlock v0.20.3",
+            "SkyBlock v0.20.2",
+            "SkyBlock v0.20.1",
+        ]
+        self.assertEqual(titles, expected_titles)
+
+    @patch('requests.get')
+    def test_search_news_by_title(self, mock_get):
+        """
+        Test searching news items by title.
+        """
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.sample_api_response
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        keyword = "v0.20.5"
+        matching_news = news_manager.search_news_by_title(keyword)
+        self.assertEqual(len(matching_news), 1)
+        self.assertEqual(matching_news[0].title, "SkyBlock v0.20.5")
+
+        keyword = "v0.20"
+        matching_news = news_manager.search_news_by_title(keyword)
+        self.assertEqual(len(matching_news), 7)
+
+    @patch('requests.get')
+    def test_get_news_by_date(self, mock_get):
+        """
+        Test retrieving news items by date.
+        """
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.sample_api_response
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        specific_date = date(2024, 10, 15)
+        news_on_date = news_manager.get_news_by_date(specific_date)
+        self.assertEqual(len(news_on_date), 1)
+        self.assertEqual(news_on_date[0].title, "SkyBlock v0.20.7")
+
+        specific_date = date(2024, 7, 9)
+        news_on_date = news_manager.get_news_by_date(specific_date)
+        self.assertEqual(len(news_on_date), 1)
+        self.assertEqual(news_on_date[0].title, "SkyBlock v0.20.4")
+
+    @patch('requests.get')
+    def test_news_item_with_missing_fields(self, mock_get):
+        """
+        Test handling of news items with missing optional fields.
+        """
+        sample_response_with_missing_fields = {
+            "success": True,
+            "items": [
+                {
+                    "item": {}, 
+                    "link": None,  
+                    "text": "1st January 2024",
+                    # Missing title and empty fields
+                }
+            ]
+        }
+
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = sample_response_with_missing_fields
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        self.assertEqual(len(news_manager.news_items), 1)
+        news_item = news_manager.news_items[0]
+        self.assertIsNone(news_item.material)
+        self.assertIsNone(news_item.link)
+        self.assertIsNone(news_item.title)
+        self.assertEqual(news_item.date_str, "1st January 2024")
+        self.assertIsNotNone(news_item.date)
+        self.assertEqual(news_item.date.year, 2024)
+        self.assertEqual(news_item.date.month, 1)
+        self.assertEqual(news_item.date.day, 1)
+
+    @patch('requests.get')
+    def test_date_parsing(self, mock_get):
+        """
+        Test the date parsing functionality of SkyBlockNewsItem.
+        """
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.sample_api_response
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        news_item = news_manager.news_items[0]
+        self.assertEqual(news_item.date.day, 15)
+        self.assertEqual(news_item.date.month, 10)
+        self.assertEqual(news_item.date.year, 2024)
+
+    @patch('requests.get')
+    def test_error_handling(self, mock_get):
+        """
+        Test the SkyBlockNews class's handling of API errors.
+        """
+        mock_get.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError("API error")
+
+        with self.assertRaises(ConnectionError) as context:
+            SkyBlockNews(api_key=self.dummy_api_key)
+
+        self.assertIn("An error occurred while fetching news: API error", str(context.exception))
+
+    @patch('requests.get')
+    def test_empty_news_list(self, mock_get):
+        """
+        Test how the SkyBlockNews class handles an empty news list.
+        """
+        empty_response = {
+            "success": True,
+            "items": []
+        }
+
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = empty_response
+
+        with self.assertRaises(ValueError) as context:
+            SkyBlockNews(api_key=self.dummy_api_key)
+
+        self.assertIn("No news data available in the response", str(context.exception))
+
+    @patch('requests.get')
+    def test_invalid_api_key(self, mock_get):
+        """
+        Test handling of invalid API key (403 error).
+        """
+        mock_get.return_value.status_code = 403
+        mock_get.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError("403 Client Error: Forbidden for url")
+
+        with self.assertRaises(PermissionError) as context:
+            SkyBlockNews(api_key=self.dummy_api_key)
+
+        self.assertIn("Access forbidden: Invalid API key.", str(context.exception))
+
+    @patch('requests.get')
+    def test_rate_limiting(self, mock_get):
+        """
+        Test handling of rate limiting (429 error).
+        """
+        mock_get.return_value.status_code = 429
+        mock_get.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError("429 Client Error: Too Many Requests for url")
+
+        with self.assertRaises(ConnectionError) as context:
+            SkyBlockNews(api_key=self.dummy_api_key)
+
+        self.assertIn("Request limit reached: Throttling in effect.", str(context.exception))
+
+    @patch('requests.get')
+    def test_date_parsing_invalid_date(self, mock_get):
+        """
+        Test handling of invalid date strings in SkyBlockNewsItem.
+        """
+        sample_response_invalid_date = {
+            "success": True,
+            "items": [
+                {
+                    "item": {"material": "INVALID_MATERIAL"},
+                    "link": "https://hypixel.net/threads/invalid/",
+                    "text": "InvalidDate",
+                    "title": "Invalid News Item"
+                }
+            ]
+        }
+
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = sample_response_invalid_date
+
+        news_manager = SkyBlockNews(api_key=self.dummy_api_key)
+
+        self.assertEqual(len(news_manager.news_items), 1)
+        news_item = news_manager.news_items[0]
+        self.assertIsNone(news_item.date)
+        self.assertEqual(news_item.date_str, "InvalidDate")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Added Skyblock News to the lib

This is the first component of the lib that is working with some api-key locked endpoints. We are starting to deal with the endpoints now that require utilizing the hypixel-api developer keys in order to pull information. There are also now rate limits and other considerations that come up since the data will start to be more complex soon. This news section is very simple and just grabs the latest news announcements that are available. Not the most useful addition but good to include and was a nice way to start working with the authentication options required for these next few endpoints.