### PR TITLE
Added Recently Ended Auctions to the Auctions Component

### DIFF
--- a/examples/recently_ended_auctions_example.py
+++ b/examples/recently_ended_auctions_example.py
@@ -1,0 +1,27 @@
+from hypixel_api_lib.Auctions import RecentlyEndedAuctions
+
+recent_auctions = RecentlyEndedAuctions()
+
+# Print the total number of recently ended auctions
+print(f"Total recently ended auctions: {len(recent_auctions.auctions)}")
+
+# Get a specific auction by its ID
+auction_id = "015fe0c67e6041e69797bbe0c2725a21"
+auction = recent_auctions.get_auction_by_id(auction_id)
+if auction:
+    print(auction)
+else:
+    print(f"Auction with ID {auction_id} not found.")
+
+# Search for auctions sold by a specific seller
+seller_uuid = "fc76242bf64a4698ae0ebc136d900929"
+seller_auctions = recent_auctions.search_auctions(seller=seller_uuid)
+print(f"Auctions sold by seller {seller_uuid}:")
+for auction in seller_auctions:
+    print(auction)
+
+# Search for BIN auctions above a certain price
+high_value_bins = recent_auctions.search_auctions(bin_only=True, min_price=1000000)
+print("High-value BIN auctions:")
+for auction in high_value_bins:
+    print(auction)


### PR DESCRIPTION
Added the recently ended auctions functionality to the auctions component. It seems to behave a bit differently than typical auction related data and it does not share the exact same structure as a typical sky block auction type. It may end up changing in the future a bit to make more sense but it does function for now enough. 

The considerations to add in the future is how we will structure the actual files of this library enable seamless and easy imports and controls. We will want to import something like hypixel_api_lib and from there be able to access the things we may want. Might be good to eventually break things like auctions out into another subfolder to create its own init.py with specific imports that only suggest the classes we want users to interface with. Even setting some classes as private may be another way to improve the current situation to prevent users from importing or using things like SkyBlockAuction directly since that is mean to just be used by either the PlayerAuctions or ActiveAuctions eventually. Something to consider for sure.