### PR TITLE
Added Dungeons Component to the SkyblockProfileMember Component within Profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Our goal with `hypixel-api-lib` is to create a comprehensive and efficient libra
 
 ## Directory Information
 
-### **hypixel-api-lib/**
+### **hypixel_api_lib/**
 
 ```sh
-geophysics_lib/
+hypixel_api_lib/
 ├── __init__.py
 ├── Elections.py
 ├── Collections.py

--- a/examples/profiles_example.py
+++ b/examples/profiles_example.py
@@ -32,8 +32,9 @@ try:
     if selected_profile:
         print(f"Selected profile for player {player_name}: {selected_profile}")
 
-        # feromond = selected_profile.get_member(player_uuid)
-        # print(feromond.events)
+        feromond = selected_profile.get_member_by_username(player_name)
+        print(feromond.dungeons)
+        print(feromond.dungeons.dungeon_types.master_catacombs.most_damage_berserk)
     else:
         print(f"No selected profile found for player UUID {player_uuid}")
 except Exception as e:

--- a/examples/profiles_example.py
+++ b/examples/profiles_example.py
@@ -6,6 +6,7 @@ load_dotenv()
 
 api_key = os.getenv("HYPIXEL_API_KEY")
 player_uuid = "be5c42d4ea454601a57b944c6413f3cd"  # Feromond
+player_name = "Feromond"
 
 profiles_api = SkyBlockProfiles(api_key)
 
@@ -27,9 +28,9 @@ except Exception as e:
 
 # Fetch the selected profile for the player
 try:
-    selected_profile = profiles_api.get_selected_profile_by_player_uuid(player_uuid)
+    selected_profile = profiles_api.get_selected_profile_by_player_name("Feromond")
     if selected_profile:
-        print(f"Selected profile for player UUID {player_uuid}: {selected_profile}")
+        print(f"Selected profile for player {player_name}: {selected_profile}")
 
         # feromond = selected_profile.get_member(player_uuid)
         # print(feromond.events)

--- a/hypixel_api_lib/Profiles.py
+++ b/hypixel_api_lib/Profiles.py
@@ -1,7 +1,7 @@
 import requests
 from datetime import datetime
 from .member.ProfileMember import SkyBlockProfileMember
-from hypixel_api_lib.utils import convert_timestamp
+from hypixel_api_lib.utils import convert_timestamp, get_uuid_from_username
 
 PROFILE_API_URL = r"https://api.hypixel.net/v2/skyblock/profile"
 PROFILES_API_URL = r"https://api.hypixel.net/v2/skyblock/profiles"
@@ -265,3 +265,47 @@ class SkyBlockProfiles:
             if profile.selected:
                 return profile
         return None
+
+    def get_profiles_by_player_name(self, username: str) -> list[SkyBlockProfile]:
+        """
+        Fetch profiles by player's username.
+
+        Args:
+            username (str): The username of the player.
+
+        Returns:
+            list[SkyBlockProfile]: List of profiles that the player is part of.
+
+        Raises:
+            ValueError: If the username does not exist or the API response indicates an error.
+            ConnectionError: If there's a network-related error.
+        """
+        try:
+            player_uuid = get_uuid_from_username(username)
+            return self.get_profiles_by_player_uuid(player_uuid)
+        except ValueError as ve:
+            raise ve
+        except ConnectionError as ce:
+            raise ce
+        
+    def get_selected_profile_by_player_name(self, username: str) -> SkyBlockProfile | None:
+        """
+        Fetch currently selected profile by player's username.
+
+        Args:
+            username (str): The username of the player.
+
+        Returns:
+            SkyBlockProfile | None: Currently selected profile of the player if it exists, or None
+
+        Raises:
+            ValueError: If the username does not exist or the API response indicates an error.
+            ConnectionError: If there's a network-related error.
+        """
+        try:
+            player_uuid = get_uuid_from_username(username)
+            return self.get_selected_profile_by_player_uuid(player_uuid)
+        except ValueError as ve:
+            raise ve
+        except ConnectionError as ce:
+            raise ce

--- a/hypixel_api_lib/member/ProfileMember.py
+++ b/hypixel_api_lib/member/ProfileMember.py
@@ -11,6 +11,7 @@ from .Leveling import LevelingData
 from .ItemData import ItemData
 from .JacobsContest import JacobsContestData
 from .Currencies import Currencies
+from .dungeons import Dungeons
 
 class DeletionNotice:
     """
@@ -79,7 +80,7 @@ class SkyBlockProfileMember:
         self.item_data: ItemData = ItemData(data.get('item_data', {}))
         self.jacobs_contest: JacobsContestData = JacobsContestData(data.get('jacobs_contest', {}))
         self.currencies: Currencies = Currencies(data.get('currencies', {}))
-        self.dungeons: dict = data.get('dungeons', {})
+        self.dungeons: Dungeons = Dungeons(data.get('dungeons', {}))
         self.profile: dict = data.get('profile', {})
         self.deleted_member: bool = self.is_member_deleted()
         self.deleted_timestamp: DeletionNotice | None = DeletionNotice(self.profile.get("deletion_notice")) if self.deleted_member else None

--- a/hypixel_api_lib/member/dungeons/DailyRuns.py
+++ b/hypixel_api_lib/member/dungeons/DailyRuns.py
@@ -1,0 +1,13 @@
+class DailyRuns():
+    """
+    DailyRuns data class to handle the dungeon daily runs component
+
+    Attributes:
+        current_day_stamp (int): the current day timestamp for the data (0 if none)
+        completed_runs_count (int): number of runs completed for the current day
+    """
+    def __init__(self, data: dict[str,int]) -> None:
+        self.current_day_stamp: int = data.get("current_day_stamp", 0)
+        self.completed_runs_count: int = data.get("completed_runs_count", 0)
+    def __str__(self) -> str:
+        return f"Current Day Stamp: {self.current_day_stamp}, Completed Runs Count: {self.completed_runs_count}"

--- a/hypixel_api_lib/member/dungeons/DailyRuns.py
+++ b/hypixel_api_lib/member/dungeons/DailyRuns.py
@@ -1,4 +1,4 @@
-class DailyRuns():
+class DailyRuns:
     """
     DailyRuns data class to handle the dungeon daily runs component
 

--- a/hypixel_api_lib/member/dungeons/DungeonHubRaceSettings.py
+++ b/hypixel_api_lib/member/dungeons/DungeonHubRaceSettings.py
@@ -1,0 +1,17 @@
+class DungeonHubRaceSettings():
+    """
+    The DungeonHubRaceSettings dataclass storing data related to the dungeon hub race settings
+
+    Attributes:
+        selected_race (str or None): Currently selected race if exists, else None
+        selected_setting (str or None): Current setting if exists, else None
+        runback (bool): whether runback is true or set to false, Default False
+
+    """
+    def __init__(self, data: dict[str,str | bool]) -> None:
+        self.selected_race: str | None = data.get("selected_race", None)
+        self.selected_setting: str | None = data.get("selected_seting", None)
+        self.runback: bool = data.get("runback", False)
+
+    def __str__(self) -> str:
+        return f"Selected Race: {self.selected_race}, Seleced Setting: {self.selected_setting}, Runback: {self.runback}"

--- a/hypixel_api_lib/member/dungeons/DungeonHubRaceSettings.py
+++ b/hypixel_api_lib/member/dungeons/DungeonHubRaceSettings.py
@@ -1,4 +1,4 @@
-class DungeonHubRaceSettings():
+class DungeonHubRaceSettings:
     """
     The DungeonHubRaceSettings dataclass storing data related to the dungeon hub race settings
 

--- a/hypixel_api_lib/member/dungeons/DungeonJournal.py
+++ b/hypixel_api_lib/member/dungeons/DungeonJournal.py
@@ -1,0 +1,12 @@
+class DungeonJournal():
+    """
+    DungeonJournal data class to handle the data within the dungeon journals.
+
+    Attributes:
+        unlocked_journals (list[str]): list of unlocked journals
+    """
+    def __init__(self, data: dict[str,list[str]]) -> None:
+        self.unlocked_journals: list[str] = data.get("unlocked_journals", {})
+
+    def __str__(self) -> str:
+        return f"Unlocked Journals: {self.unlocked_journals}"

--- a/hypixel_api_lib/member/dungeons/DungeonJournal.py
+++ b/hypixel_api_lib/member/dungeons/DungeonJournal.py
@@ -1,4 +1,4 @@
-class DungeonJournal():
+class DungeonJournal:
     """
     DungeonJournal data class to handle the data within the dungeon journals.
 

--- a/hypixel_api_lib/member/dungeons/DungeonTypes.py
+++ b/hypixel_api_lib/member/dungeons/DungeonTypes.py
@@ -151,7 +151,7 @@ class TimesPlayedCatacombs(TotalStats):
         return f"Times Played for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
 
 
-class Catacombs: #TODO test all these to verify
+class Catacombs:
     def __init__(self, data:dict) -> None:
         self.times_played: TimesPlayedCatacombs = TimesPlayedCatacombs(data.get("times_played", {}))
         self.experience: float = data.get("experience", 0.0)

--- a/hypixel_api_lib/member/dungeons/DungeonTypes.py
+++ b/hypixel_api_lib/member/dungeons/DungeonTypes.py
@@ -48,6 +48,12 @@ class DungeonRun:
                 f"Damage Mitigated: {self.damage_mitigated}, Ally Healing: {self.ally_healing}")
 
 class DungeonRuns:
+    """
+    The DungeonRuns class stores a collection of DungeonRun objects.
+    
+    Attributes:
+        dungeon_runs (list[DungeonRun]): A list of DungeonRun objects representing individual runs.
+    """
     def __init__(self, list_of_runs: list[dict]) -> None:
         self.dungeon_runs = []
         for run in list_of_runs:
@@ -76,11 +82,23 @@ class FloorStats:
         self.floor7: float = data.get("7", 0.0)
 
 class BestStats(FloorStats):
+    """
+    BestStats class extends FloorStats to include the best recorded stat across all floors.
+    
+    Attributes:
+        best (float): The highest value recorded across all floors.
+    """
     def __init__(self, data: dict[str,float]) -> None:
         super().__init__(data)
         self.best: float = data.get("best", None)
     
 class TotalStats(FloorStats):
+    """
+    TotalStats class extends FloorStats to include the total stat value for all floors combined.
+
+    Attributes:
+        total (float): The combined total across all floors.
+    """
     def __init__(self, data: dict[str,float]) -> None:
         super().__init__(data)
         self.total: float = data.get("total", None)
@@ -152,6 +170,50 @@ class TimesPlayedCatacombs(TotalStats):
 
 
 class Catacombs:
+    """
+    The Catacombs class stores data related to Catacombs dungeon statistics. 
+    This includes a wide range of metrics tracked across various floors 
+    within the Catacombs dungeon, such as times played, experience earned, 
+    best scores, mob kills, and damage dealt by different classes.
+
+    Attributes:
+        times_played (TimesPlayedCatacombs): Tracks the total play counts for each floor, 
+            including the total number of runs across all floors.
+        experience (float): Total experience points earned in the Catacombs dungeon.
+        best_score (BestScore): The highest score achieved on each floor, with the best score recorded.
+        mobs_killed (MobsKilled): Tracks the cumulative number of mobs killed per floor, 
+            including the total for all floors.
+        most_mobs_killed (MostMobsKilled): The highest number of mobs killed in a single run 
+            for each floor, as well as the highest single run across all floors.
+        most_damage_berserk (MostDamageBerserk): Records the highest damage dealt 
+            by a player in the Berserk class on each floor and overall.
+        most_healing (MostHealing): Records the highest amount of healing done 
+            on each floor by any player class, as well as the highest recorded.
+        tier_completions (TierCompletions): Tracks the number of tier completions for each floor 
+            and the total number of tiers completed.
+        fastest_time (FastestTime): Tracks the fastest completion time for each floor, 
+            as well as the fastest time overall.
+        best_runs (BestRuns): A collection of DungeonRuns objects representing the best runs 
+            for each floor.
+        watcher_kills (WatcherKills): Records the total number of Watcher mobs killed 
+            on each floor and in total.
+        highest_tier_completed (int | None): The highest Catacombs tier that has been completed, 
+            if available.
+        fastest_time_s (FastestTimeS): The fastest completion time with an S rank on each floor 
+            and overall.
+        most_damage_mage (MostDamageMage): Records the highest damage dealt by a Mage 
+            on each floor and overall.
+        most_damage_tank (MostDamageTank): Records the highest damage dealt by a Tank 
+            on each floor and overall.
+        fastest_time_s_plus (FastestTimeSPlus): The fastest completion time with an S+ rank 
+            on each floor and overall.
+        most_damage_archer (MostDamageArcher): Records the highest damage dealt by an Archer 
+            on each floor and overall.
+        most_damage_healer (MostDamageHealer): Records the highest damage dealt by a Healer 
+            on each floor and overall.
+        milestone_completions (MilestoneCompletions): Tracks the milestone completions for each floor 
+            and the total milestone completions across all floors.
+    """
     def __init__(self, data:dict) -> None:
         self.times_played: TimesPlayedCatacombs = TimesPlayedCatacombs(data.get("times_played", {}))
         self.experience: float = data.get("experience", 0.0)
@@ -177,6 +239,38 @@ class Catacombs:
 
 
 class MasterCatacombs:
+    """
+    The MasterCatacombs class stores data specific to the Master Catacombs dungeon. 
+    This dungeon is a more challenging version of the Catacombs, with similar metrics 
+    being tracked. It records performance in areas like damage dealt, mobs killed, 
+    and fastest times, across multiple floors.
+
+    Attributes:
+        tier_completions (TierCompletions): The number of tier completions per floor 
+            and total for all floors.
+        milestone_completions (MilestoneCompletions): Tracks the milestone completions per floor 
+            and the total milestone completions for all floors.
+        best_score (BestScore): The best score achieved on each floor, as well as the highest overall.
+        mobs_killed (MobsKilled): The cumulative number of mobs killed on each floor and in total.
+        most_mobs_killed (MostMobsKilled): The highest single-run mob kill count on each floor 
+            and overall.
+        most_damage_berserk (MostDamageBerserk): The highest damage dealt by a Berserk 
+            on each floor and in total.
+        most_healing (MostHealing): The maximum healing done on each floor and the highest recorded.
+        fastest_time (FastestTime): The fastest completion time for each floor and overall.
+        highest_tier_completed (int | None): The highest tier completed in Master Catacombs, if available.
+        fastest_time_s (FastestTimeS): The fastest time with an S rank on each floor and overall.
+        best_runs (BestRuns): A collection of DungeonRuns objects representing the best runs 
+            for each floor.
+        most_damage_mage (MostDamageMage): Records the highest damage dealt by a Mage 
+            on each floor and overall.
+        most_damage_archer (MostDamageArcher): Records the highest damage dealt by an Archer 
+            on each floor and overall.
+        fastest_time_s_plus (FastestTimeSPlus): The fastest time with an S+ rank on each floor 
+            and overall.
+        most_damage_healer (MostDamageHealer): Records the highest damage dealt by a Healer 
+            on each floor and overall.
+    """
     def __init__(self, data: dict) -> None:
         self.tier_completions: TierCompletions = TierCompletions(data.get("tier_completions", {}))
         self.milestone_completions: MilestoneCompletions = MilestoneCompletions(data.get("milestone_completions", {}))
@@ -193,14 +287,20 @@ class MasterCatacombs:
         self.most_damage_archer: MostDamageArcher = MostDamageArcher(data.get("most_damage_archer", {}))
         self.fastest_time_s_plus: FastestTimeSPlus = FastestTimeSPlus(data.get("fastest_time_s_plus", {}))
         self.most_damage_healer: MostDamageHealer = MostDamageHealer(data.get("most_damage_healer", {}))
-        
-"""
-Master Catacombs
- 'most_damage_mage', 'most_damage_archer', 'fastest_time_s_plus', 'most_damage_healer'])
-"""
-
 
 class DungeonTypes:
+    """
+    The DungeonTypes class encapsulates data for different types of dungeons 
+    in the game. Specifically, it contains data for the standard Catacombs dungeon 
+    and the more challenging Master Catacombs.
+
+    Attributes:
+        catacombs (Catacombs): An instance of the Catacombs class containing 
+            detailed stats and metrics for the standard Catacombs dungeon.
+        master_catacombs (MasterCatacombs): An instance of the MasterCatacombs class 
+            containing stats and metrics for the Master Catacombs dungeon, 
+            which is more challenging.
+    """
     def __init__(self, data: dict) -> None:
         self.catacombs: dict = Catacombs(data.get("catacombs", {}))
         self.master_catacombs: dict = MasterCatacombs(data.get("master_catacombs", {}))

--- a/hypixel_api_lib/member/dungeons/DungeonTypes.py
+++ b/hypixel_api_lib/member/dungeons/DungeonTypes.py
@@ -1,0 +1,85 @@
+class FloorStats():
+    def __init__(self, data: dict[str,float]) -> None:
+        self.floor0: float = data.get("0", 0.0)
+        self.floor1: float = data.get("1", 0.0)
+        self.floor2: float = data.get("2", 0.0)
+        self.floor3: float = data.get("3", 0.0)
+        self.floor4: float = data.get("4", 0.0)
+        self.floor5: float = data.get("5", 0.0)
+        self.floor6: float = data.get("6", 0.0)
+        self.floor7: float = data.get("7", 0.0)
+
+class BestStats(FloorStats):
+    def __init__(self, data: dict[str,float]) -> None:
+        super().__init__(data)
+        self.best: float = data.get("best")
+    
+class TotalStats(FloorStats):
+    def __init__(self, data: dict[str,float]) -> None:
+        super().__init__(data)
+        self.total: float = data.get("total")
+
+class FastestTime(BestStats):
+    def __str__(self) -> None:
+        return f"Fastest Times for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+class TierCompletions(TotalStats):
+    def __str__(self) -> None:
+        return f"Tier Completions for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
+
+class MostHealing(BestStats):
+    def __str__(self) -> None:
+        return f"Most Healing for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+class MostDamageBerserk(FloorStats):
+    def __str__(self) -> None:
+        return f"Most Berserk Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}"
+
+class MostMobsKilled(BestStats):
+    def __str__(self) -> str:
+        return f"Most Mobs Killed for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+
+class MobsKilled(TotalStats):
+    def __str__(self) -> str:
+        return f"Mobs Killed In Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
+
+
+class BestScore(BestStats):
+    def __str__(self) -> str:
+        return f"Best Score for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+
+class TimesPlayedCatacombs(TotalStats):
+    def __str__(self) -> str:
+        return f"Times Played for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
+
+
+class Catacombs():
+    def __init__(self, data:dict) -> None:
+        self.times_played: TimesPlayedCatacombs = TimesPlayedCatacombs(data.get("times_played", {}))
+        self.experience: float = data.get("experience", 0.0)
+        self.best_score: BestScore = BestScore(data.get("best_score", {}))
+        self.mobs_killed: MobsKilled = MobsKilled(data.get("mobs_killed", {}))
+        self.most_mobs_killed: MostMobsKilled = MostMobsKilled(data.get("most_mobs_killed", {}))
+        self.most_damage_berserk: MostDamageBerserk = MostDamageBerserk(data.get("most_damage_berserk", {}))
+        self.most_healing: MostHealing = MostHealing(data.get("most_healing", {}))
+        self.tier_completions: TierCompletions = TierCompletions(data.get("tier_completions", {}))
+        self.fastest_time: FastestTime = FastestTime(data.get("fastest_time", {}))
+
+
+"""
+Catacombs
+ 'best_runs', 'watcher_kills', 'highest_tier_completed', 'fastest_time_s', 'most_damage_mage', 'most_damage_tank', 'fastest_time_s_plus', 'most_damage_archer', 'most_damage_healer', 'milestone_completions'])
+
+Master Catacombs
+dict_keys(['tier_completions', 'milestone_completions', 'best_score', 'mobs_killed', 'most_mobs_killed', 'most_damage_berserk', 'most_healing', 'fastest_time', 'highest_tier_completed', 'fastest_time_s', 'best_runs', 'most_damage_mage', 'most_damage_archer', 'fastest_time_s_plus', 'most_damage_healer'])
+"""
+
+
+
+class DungeonTypes():
+    def __init__(self, data: dict) -> None:
+        self.catacombs: dict = data.get("catacombs", {})
+        self.master_catacombs: dict = data.get("master_catacombs")
+

--- a/hypixel_api_lib/member/dungeons/DungeonTypes.py
+++ b/hypixel_api_lib/member/dungeons/DungeonTypes.py
@@ -52,19 +52,17 @@ class DungeonRuns:
         self.dungeon_runs = []
         for run in list_of_runs:
             self.dungeon_runs.append(DungeonRun(run))
-            
-
+         
 class BestRuns:
     def __init__(self, data: dict[str,dict]) -> None:
-        self.floor0: list[dict] = data.get("0", [])
-        self.floor1: list[dict] = data.get("1", [])
-        self.floor2: list[dict] = data.get("2", [])
-        self.floor3: list[dict] = data.get("3", [])
-        self.floor4: list[dict] = data.get("4", [])
-        self.floor5: list[dict] = data.get("5", [])
-        self.floor6: list[dict] = data.get("6", [])
-        self.floor7: list[dict] = data.get("7", [])
-    
+        self.floor0: DungeonRuns = DungeonRuns(data.get("0", []))
+        self.floor1: DungeonRuns = DungeonRuns(data.get("1", []))
+        self.floor2: DungeonRuns = DungeonRuns(data.get("2", []))
+        self.floor3: DungeonRuns = DungeonRuns(data.get("3", []))
+        self.floor4: DungeonRuns = DungeonRuns(data.get("4", []))
+        self.floor5: DungeonRuns = DungeonRuns(data.get("5", []))
+        self.floor6: DungeonRuns = DungeonRuns(data.get("6", []))
+        self.floor7: DungeonRuns = DungeonRuns(data.get("7", []))
 
 class FloorStats:
     def __init__(self, data: dict[str,float]) -> None:
@@ -80,20 +78,40 @@ class FloorStats:
 class BestStats(FloorStats):
     def __init__(self, data: dict[str,float]) -> None:
         super().__init__(data)
-        self.best: float = data.get("best")
+        self.best: float = data.get("best", None)
     
 class TotalStats(FloorStats):
     def __init__(self, data: dict[str,float]) -> None:
         super().__init__(data)
-        self.total: float = data.get("total")
+        self.total: float = data.get("total", None)
 
+class MilestoneCompletions(TotalStats):
+    def __str__(self) -> str:
+        return f"Milestones Completed In Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
+
+class MostDamageHealer(BestStats):
+    def __str__(self) -> str:
+        return f"Most Healer Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+class MostDamageArcher(BestStats):
+    def __str__(self) -> str:
+        return f"Most Archer Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+class FastestTimeSPlus(BestStats):
+    def __str__(self) -> str:
+        return f"Fastest S+ Times for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+class MostDamageTank(BestStats):
+    def __str__(self) -> str:
+        return f"Most Tank Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+    
 class MostDamageMage(BestStats):
     def __str__(self) -> str:
         return f"Most Mage Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
 
-class FastestTimeS(FloorStats):
+class FastestTimeS(BestStats):
     def __str__(self) -> str:
-        return f"Fastest S Times for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}"
+        return f"Fastest S Times for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
 
 class WatcherKills(TotalStats):
     def __str__(self) -> str:
@@ -111,9 +129,9 @@ class MostHealing(BestStats):
     def __str__(self) -> str:
         return f"Most Healing for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
 
-class MostDamageBerserk(FloorStats):
+class MostDamageBerserk(BestStats):
     def __str__(self) -> str:
-        return f"Most Berserk Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}"
+        return f"Most Berserk Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
 
 class MostMobsKilled(BestStats):
     def __str__(self) -> str:
@@ -149,11 +167,13 @@ class Catacombs: #TODO test all these to verify
         self.highest_tier_completed: int | None = data.get("highest_tier_completed", None)
         self.fastest_time_s: FastestTimeS = FastestTimeS(data.get("fastest_time_s", {}))
         self.most_damage_mage: MostDamageMage = MostDamageMage(data.get("most_damage_mage", {}))
+        self.most_damage_tank: MostDamageTank = MostDamageTank(data.get("most_damage_tank", {}))
+        self.fastest_time_s_plus: FastestTimeSPlus = FastestTimeSPlus(data.get("fastest_time_s_plus", {}))
+        self.most_damage_archer: MostDamageArcher = MostDamageArcher(data.get("most_damage_archer", {}))
+        self.most_damage_healer: MostDamageHealer = MostDamageHealer(data.get("most_damage_healer", {}))
+        self.milestone_completions: MilestoneCompletions = MilestoneCompletions(data.get("milestone_completions", {}))
 
 """
-Catacombs
- 'most_damage_tank', 'fastest_time_s_plus', 'most_damage_archer', 'most_damage_healer', 'milestone_completions'])
-
 Master Catacombs
 dict_keys(['tier_completions', 'milestone_completions', 'best_score', 'mobs_killed', 'most_mobs_killed', 'most_damage_berserk', 'most_healing', 'fastest_time', 'highest_tier_completed', 'fastest_time_s', 'best_runs', 'most_damage_mage', 'most_damage_archer', 'fastest_time_s_plus', 'most_damage_healer'])
 """
@@ -162,6 +182,6 @@ dict_keys(['tier_completions', 'milestone_completions', 'best_score', 'mobs_kill
 
 class DungeonTypes:
     def __init__(self, data: dict) -> None:
-        self.catacombs: dict = data.get("catacombs", {})
+        self.catacombs: dict = Catacombs(data.get("catacombs", {}))
         self.master_catacombs: dict = data.get("master_catacombs")
 

--- a/hypixel_api_lib/member/dungeons/DungeonTypes.py
+++ b/hypixel_api_lib/member/dungeons/DungeonTypes.py
@@ -1,4 +1,72 @@
-class FloorStats():
+from datetime import datetime
+class DungeonRun:
+    """
+    The DungeonRun class stores data related to a dungeon run.
+
+    Attributes:
+        timestamp (datetime): The timestamp of the run in datetime format.
+        score_exploration (int): Exploration score achieved in the run.
+        score_speed (int): Speed score achieved in the run.
+        score_skill (int): Skill score achieved in the run.
+        score_bonus (int): Bonus score achieved in the run.
+        dungeon_class (str): Class type of the dungeon (e.g., 'berserk').
+        teammates (list[str]): List of teammate IDs.
+        elapsed_time (int): Time taken for the run in milliseconds.
+        damage_dealt (float): Total damage dealt by the player.
+        deaths (int): Number of deaths in the run.
+        mobs_killed (int): Number of mobs killed.
+        secrets_found (int): Number of secrets found.
+        damage_mitigated (float): Total damage mitigated.
+        ally_healing (float): Total healing done to allies.
+    """
+
+    def __init__(self, data: dict) -> None:
+        self.timestamp: datetime = datetime.fromtimestamp(data.get("timestamp", 0) / 1000)
+        self.score_exploration: int = data.get("score_exploration", 0)
+        self.score_speed: int = data.get("score_speed", 0)
+        self.score_skill: int = data.get("score_skill", 0)
+        self.score_bonus: int = data.get("score_bonus", 0)
+        self.dungeon_class: str = data.get("dungeon_class", "unknown")
+        self.teammates: list[str] = data.get("teammates", [])   # TODO: Add conversion from UUID to usernames
+        self.elapsed_time: int = data.get("elapsed_time", 0)
+        self.damage_dealt: float = data.get("damage_dealt", 0.0)
+        self.deaths: int = data.get("deaths", 0)
+        self.mobs_killed: int = data.get("mobs_killed", 0)
+        self.secrets_found: int = data.get("secrets_found", 0)
+        self.damage_mitigated: float = data.get("damage_mitigated", 0.0)
+        self.ally_healing: float = data.get("ally_healing", 0.0)
+
+    def __str__(self) -> str:
+        return (f"Dungeon Run on {self.timestamp}: "
+                f"Class: {self.dungeon_class}, "
+                f"Scores - Exploration: {self.score_exploration}, Speed: {self.score_speed}, "
+                f"Skill: {self.score_skill}, Bonus: {self.score_bonus}, "
+                f"Teammates: {', '.join(self.teammates)}, "
+                f"Elapsed Time: {self.elapsed_time}ms, "
+                f"Damage Dealt: {self.damage_dealt}, Deaths: {self.deaths}, "
+                f"Mobs Killed: {self.mobs_killed}, Secrets Found: {self.secrets_found}, "
+                f"Damage Mitigated: {self.damage_mitigated}, Ally Healing: {self.ally_healing}")
+
+class DungeonRuns:
+    def __init__(self, list_of_runs: list[dict]) -> None:
+        self.dungeon_runs = []
+        for run in list_of_runs:
+            self.dungeon_runs.append(DungeonRun(run))
+            
+
+class BestRuns:
+    def __init__(self, data: dict[str,dict]) -> None:
+        self.floor0: list[dict] = data.get("0", [])
+        self.floor1: list[dict] = data.get("1", [])
+        self.floor2: list[dict] = data.get("2", [])
+        self.floor3: list[dict] = data.get("3", [])
+        self.floor4: list[dict] = data.get("4", [])
+        self.floor5: list[dict] = data.get("5", [])
+        self.floor6: list[dict] = data.get("6", [])
+        self.floor7: list[dict] = data.get("7", [])
+    
+
+class FloorStats:
     def __init__(self, data: dict[str,float]) -> None:
         self.floor0: float = data.get("0", 0.0)
         self.floor1: float = data.get("1", 0.0)
@@ -19,31 +87,41 @@ class TotalStats(FloorStats):
         super().__init__(data)
         self.total: float = data.get("total")
 
+class MostDamageMage(BestStats):
+    def __str__(self) -> str:
+        return f"Most Mage Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
+
+class FastestTimeS(FloorStats):
+    def __str__(self) -> str:
+        return f"Fastest S Times for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}"
+
+class WatcherKills(TotalStats):
+    def __str__(self) -> str:
+        return f"Watchers Killed In Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
+
 class FastestTime(BestStats):
-    def __str__(self) -> None:
+    def __str__(self) -> str:
         return f"Fastest Times for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
 
 class TierCompletions(TotalStats):
-    def __str__(self) -> None:
+    def __str__(self) -> str:
         return f"Tier Completions for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
 
 class MostHealing(BestStats):
-    def __str__(self) -> None:
+    def __str__(self) -> str:
         return f"Most Healing for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
 
 class MostDamageBerserk(FloorStats):
-    def __str__(self) -> None:
+    def __str__(self) -> str:
         return f"Most Berserk Damage for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}"
 
 class MostMobsKilled(BestStats):
     def __str__(self) -> str:
         return f"Most Mobs Killed for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, best: {self.best}"
 
-
 class MobsKilled(TotalStats):
     def __str__(self) -> str:
         return f"Mobs Killed In Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
-
 
 class BestScore(BestStats):
     def __str__(self) -> str:
@@ -55,7 +133,7 @@ class TimesPlayedCatacombs(TotalStats):
         return f"Times Played for Entrance: {self.floor0}, Floor 1: {self.floor1}, Floor 2: {self.floor2}, Floor 3: {self.floor3}, Floor 4: {self.floor4}, Floor 5: {self.floor5}, Floor 6: {self.floor6}, Floor 7: {self.floor7}, Total: {self.total}"
 
 
-class Catacombs():
+class Catacombs: #TODO test all these to verify
     def __init__(self, data:dict) -> None:
         self.times_played: TimesPlayedCatacombs = TimesPlayedCatacombs(data.get("times_played", {}))
         self.experience: float = data.get("experience", 0.0)
@@ -66,11 +144,15 @@ class Catacombs():
         self.most_healing: MostHealing = MostHealing(data.get("most_healing", {}))
         self.tier_completions: TierCompletions = TierCompletions(data.get("tier_completions", {}))
         self.fastest_time: FastestTime = FastestTime(data.get("fastest_time", {}))
-
+        self.best_runs: BestRuns = BestRuns(data.get("best_runs", {}))
+        self.watcher_kills: WatcherKills = WatcherKills(data.get("watcher_kills", {}))
+        self.highest_tier_completed: int | None = data.get("highest_tier_completed", None)
+        self.fastest_time_s: FastestTimeS = FastestTimeS(data.get("fastest_time_s", {}))
+        self.most_damage_mage: MostDamageMage = MostDamageMage(data.get("most_damage_mage", {}))
 
 """
 Catacombs
- 'best_runs', 'watcher_kills', 'highest_tier_completed', 'fastest_time_s', 'most_damage_mage', 'most_damage_tank', 'fastest_time_s_plus', 'most_damage_archer', 'most_damage_healer', 'milestone_completions'])
+ 'most_damage_tank', 'fastest_time_s_plus', 'most_damage_archer', 'most_damage_healer', 'milestone_completions'])
 
 Master Catacombs
 dict_keys(['tier_completions', 'milestone_completions', 'best_score', 'mobs_killed', 'most_mobs_killed', 'most_damage_berserk', 'most_healing', 'fastest_time', 'highest_tier_completed', 'fastest_time_s', 'best_runs', 'most_damage_mage', 'most_damage_archer', 'fastest_time_s_plus', 'most_damage_healer'])
@@ -78,7 +160,7 @@ dict_keys(['tier_completions', 'milestone_completions', 'best_score', 'mobs_kill
 
 
 
-class DungeonTypes():
+class DungeonTypes:
     def __init__(self, data: dict) -> None:
         self.catacombs: dict = data.get("catacombs", {})
         self.master_catacombs: dict = data.get("master_catacombs")

--- a/hypixel_api_lib/member/dungeons/DungeonTypes.py
+++ b/hypixel_api_lib/member/dungeons/DungeonTypes.py
@@ -173,15 +173,35 @@ class Catacombs: #TODO test all these to verify
         self.most_damage_healer: MostDamageHealer = MostDamageHealer(data.get("most_damage_healer", {}))
         self.milestone_completions: MilestoneCompletions = MilestoneCompletions(data.get("milestone_completions", {}))
 
+
+
+
+class MasterCatacombs:
+    def __init__(self, data: dict) -> None:
+        self.tier_completions: TierCompletions = TierCompletions(data.get("tier_completions", {}))
+        self.milestone_completions: MilestoneCompletions = MilestoneCompletions(data.get("milestone_completions", {}))
+        self.best_score: BestScore = BestScore(data.get("best_score", {}))
+        self.mobs_killed: MobsKilled = MobsKilled(data.get("mobs_killed", {}))
+        self.most_mobs_killed: MostMobsKilled = MostMobsKilled(data.get("most_mobs_killed", {}))
+        self.most_damage_berserk: MostDamageBerserk = MostDamageBerserk(data.get("most_damage_berserk", {}))
+        self.most_healing: MostHealing = MostHealing(data.get("most_healing", {}))
+        self.fastest_time: FastestTime = FastestTime(data.get("fastest_time", {}))
+        self.highest_tier_completed: int | None = data.get("highest_tier_completed", None)
+        self.fastest_time_s: FastestTimeS = FastestTimeS(data.get("fastest_time_s", {}))
+        self.best_runs: BestRuns = BestRuns(data.get("best_runs", {}))
+        self.most_damage_mage: MostDamageMage = MostDamageMage(data.get("most_damage_mage", {}))
+        self.most_damage_archer: MostDamageArcher = MostDamageArcher(data.get("most_damage_archer", {}))
+        self.fastest_time_s_plus: FastestTimeSPlus = FastestTimeSPlus(data.get("fastest_time_s_plus", {}))
+        self.most_damage_healer: MostDamageHealer = MostDamageHealer(data.get("most_damage_healer", {}))
+        
 """
 Master Catacombs
-dict_keys(['tier_completions', 'milestone_completions', 'best_score', 'mobs_killed', 'most_mobs_killed', 'most_damage_berserk', 'most_healing', 'fastest_time', 'highest_tier_completed', 'fastest_time_s', 'best_runs', 'most_damage_mage', 'most_damage_archer', 'fastest_time_s_plus', 'most_damage_healer'])
+ 'most_damage_mage', 'most_damage_archer', 'fastest_time_s_plus', 'most_damage_healer'])
 """
-
 
 
 class DungeonTypes:
     def __init__(self, data: dict) -> None:
         self.catacombs: dict = Catacombs(data.get("catacombs", {}))
-        self.master_catacombs: dict = data.get("master_catacombs")
+        self.master_catacombs: dict = MasterCatacombs(data.get("master_catacombs", {}))
 

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -2,6 +2,7 @@ from .PlayerClasses import PlayerClasses
 from .DungeonJournal import DungeonJournal
 from .DailyRuns import DailyRuns
 from .DungeonHubRaceSettings import DungeonHubRaceSettings
+from .DungeonTypes import DungeonTypes
 
 class Dungeons():
     """

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -15,7 +15,7 @@ class Dungeons:
     def __init__(self, dungeons_data: dict) -> None:
         self.dungeons_data = dungeons_data
 
-        self.dungeon_types: dict = dungeons_data.get("dungeon_types", {})                       # Huge
+        self.dungeon_types: dict = DungeonTypes(dungeons_data.get("dungeon_types", {})   )                   # Huge
         self.player_classes: PlayerClasses = PlayerClasses(dungeons_data.get("player_classes", {})) 
         self.dungeon_journal: DungeonJournal = DungeonJournal(dungeons_data.get("dungeon_journal", {}))
         self.dungeons_blah_blah: list[str] = dungeons_data.get("dungeons_blah_blah", [])

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -15,7 +15,7 @@ class Dungeons:
     def __init__(self, dungeons_data: dict) -> None:
         self.dungeons_data = dungeons_data
 
-        self.dungeon_types: dict = DungeonTypes(dungeons_data.get("dungeon_types", {})   )                   # Huge
+        self.dungeon_types: dict = DungeonTypes(dungeons_data.get("dungeon_types", {}))
         self.player_classes: PlayerClasses = PlayerClasses(dungeons_data.get("player_classes", {})) 
         self.dungeon_journal: DungeonJournal = DungeonJournal(dungeons_data.get("dungeon_journal", {}))
         self.dungeons_blah_blah: list[str] = dungeons_data.get("dungeons_blah_blah", [])

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -1,6 +1,7 @@
 from .PlayerClasses import PlayerClasses
 from .DungeonJournal import DungeonJournal
 from .DailyRuns import DailyRuns
+from .DungeonHubRaceSettings import DungeonHubRaceSettings
 
 class Dungeons():
     """
@@ -20,7 +21,7 @@ class Dungeons():
         self.selected_dungeon_class: str | None = dungeons_data.get("selected_dungeon_class", None)
         self.daily_runs: DailyRuns = DailyRuns(dungeons_data.get("daily_runs", {}))
         self.treasures: dict = dungeons_data.get("treasures", {})                               # Huge
-        self.dungeon_hub_race_settings: dict[str,str] = dungeons_data.get("dungeon_hub_race_settings", {}) 
+        self.dungeon_hub_race_settings: DungeonHubRaceSettings =  DungeonHubRaceSettings(dungeons_data.get("dungeon_hub_race_settings", {}))
         self.last_dungeon_run: str | None = dungeons_data.get("last_dungeon_run", None)
         self.secrets: int = dungeons_data.get("secrets", 0)
 

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -4,7 +4,7 @@ from .DailyRuns import DailyRuns
 from .DungeonHubRaceSettings import DungeonHubRaceSettings
 from .DungeonTypes import DungeonTypes
 
-class Dungeons():
+class Dungeons:
     """
     The dungeons class to handle and store all dungeon related data for a SkyBlockProfileMember
 

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -3,25 +3,34 @@ from .DungeonJournal import DungeonJournal
 from .DailyRuns import DailyRuns
 from .DungeonHubRaceSettings import DungeonHubRaceSettings
 from .DungeonTypes import DungeonTypes
+from .Treasures import Treasures
 
 class Dungeons:
     """
-    The dungeons class to handle and store all dungeon related data for a SkyBlockProfileMember
+    Handles and stores all dungeon-related data for a SkyBlock profile member.
 
     Attributes:
-        dungeon_types (DungeonTypes): ...
+        dungeon_types (DungeonTypes): Represents the types of dungeons and their respective data.
+        player_classes (PlayerClasses): Contains information about the player's dungeon classes.
+        dungeon_journal (DungeonJournal): Holds the player's dungeon journal entries.
+        dungeons_blah_blah (list of str): List NPC's the member has talked to.
+        selected_dungeon_class (str or None): The class selected by the player for dungeons (e.g., 'Mage', 'Healer').
+        daily_runs (DailyRuns): Contains data about the player's daily dungeon runs.
+        treasures (Treasures): Represents the treasures (runs and chests) acquired in dungeons.
+        dungeon_hub_race_settings (DungeonHubRaceSettings): Settings related to the Dungeon Hub races.
+        last_dungeon_run (str or None): Timestamp or identifier of the player's last dungeon run.
+        secrets (int): The total number of secrets found by the player in dungeons.
     """
-
     def __init__(self, dungeons_data: dict) -> None:
-        self.dungeons_data = dungeons_data
+        self.dungeons_data: dict = dungeons_data
 
-        self.dungeon_types: dict = DungeonTypes(dungeons_data.get("dungeon_types", {}))
+        self.dungeon_types: DungeonTypes = DungeonTypes(dungeons_data.get("dungeon_types", {}))
         self.player_classes: PlayerClasses = PlayerClasses(dungeons_data.get("player_classes", {})) 
         self.dungeon_journal: DungeonJournal = DungeonJournal(dungeons_data.get("dungeon_journal", {}))
         self.dungeons_blah_blah: list[str] = dungeons_data.get("dungeons_blah_blah", [])
         self.selected_dungeon_class: str | None = dungeons_data.get("selected_dungeon_class", None)
         self.daily_runs: DailyRuns = DailyRuns(dungeons_data.get("daily_runs", {}))
-        self.treasures: dict = dungeons_data.get("treasures", {})                               # Huge
+        self.treasures: Treasures = Treasures(dungeons_data.get("treasures", {}))
         self.dungeon_hub_race_settings: DungeonHubRaceSettings =  DungeonHubRaceSettings(dungeons_data.get("dungeon_hub_race_settings", {}))
         self.last_dungeon_run: str | None = dungeons_data.get("last_dungeon_run", None)
         self.secrets: int = dungeons_data.get("secrets", 0)

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -1,4 +1,6 @@
 from .PlayerClasses import PlayerClasses
+from .DungeonJournal import DungeonJournal
+from .DailyRuns import DailyRuns
 
 class Dungeons():
     """
@@ -13,10 +15,10 @@ class Dungeons():
 
         self.dungeon_types: dict = dungeons_data.get("dungeon_types", {})                       # Huge
         self.player_classes: PlayerClasses = PlayerClasses(dungeons_data.get("player_classes", {})) 
-        self.dungeon_journal: dict[str,list[str]] = dungeons_data.get("dungeon_journal", {}) 
+        self.dungeon_journal: DungeonJournal = DungeonJournal(dungeons_data.get("dungeon_journal", {}))
         self.dungeons_blah_blah: list[str] = dungeons_data.get("dungeons_blah_blah", [])
         self.selected_dungeon_class: str | None = dungeons_data.get("selected_dungeon_class", None)
-        self.daily_runs: dict[str,int] = dungeons_data.get("daily_runs", {})
+        self.daily_runs: DailyRuns = DailyRuns(dungeons_data.get("daily_runs", {}))
         self.treasures: dict = dungeons_data.get("treasures", {})                               # Huge
         self.dungeon_hub_race_settings: dict[str,str] = dungeons_data.get("dungeon_hub_race_settings", {}) 
         self.last_dungeon_run: str | None = dungeons_data.get("last_dungeon_run", None)

--- a/hypixel_api_lib/member/dungeons/Dungeons.py
+++ b/hypixel_api_lib/member/dungeons/Dungeons.py
@@ -1,0 +1,27 @@
+from .PlayerClasses import PlayerClasses
+
+class Dungeons():
+    """
+    The dungeons class to handle and store all dungeon related data for a SkyBlockProfileMember
+
+    Attributes:
+        dungeon_types (DungeonTypes): ...
+    """
+
+    def __init__(self, dungeons_data: dict) -> None:
+        self.dungeons_data = dungeons_data
+
+        self.dungeon_types: dict = dungeons_data.get("dungeon_types", {})                       # Huge
+        self.player_classes: PlayerClasses = PlayerClasses(dungeons_data.get("player_classes", {})) 
+        self.dungeon_journal: dict[str,list[str]] = dungeons_data.get("dungeon_journal", {}) 
+        self.dungeons_blah_blah: list[str] = dungeons_data.get("dungeons_blah_blah", [])
+        self.selected_dungeon_class: str | None = dungeons_data.get("selected_dungeon_class", None)
+        self.daily_runs: dict[str,int] = dungeons_data.get("daily_runs", {})
+        self.treasures: dict = dungeons_data.get("treasures", {})                               # Huge
+        self.dungeon_hub_race_settings: dict[str,str] = dungeons_data.get("dungeon_hub_race_settings", {}) 
+        self.last_dungeon_run: str | None = dungeons_data.get("last_dungeon_run", None)
+        self.secrets: int = dungeons_data.get("secrets", 0)
+
+
+    def __str__(self) -> str:
+        return f"Dungeons Data Class containing: {self.dungeons_data.keys()}"

--- a/hypixel_api_lib/member/dungeons/PlayerClasses.py
+++ b/hypixel_api_lib/member/dungeons/PlayerClasses.py
@@ -1,0 +1,37 @@
+class ClassExperience():
+    """
+    Represents a specific dungeon class experience.
+
+    Attributes:
+        experience (float): The collected experience for a given class
+    """
+    def __init__(self, data: dict[str,float]) -> None:
+        self.experience: float = data.get("experience", 0.0)
+    
+    def __str__(self) -> str:
+        return f"Experience: {self.experience}"
+
+class PlayerClasses():
+    """
+    All dungeons player classes
+
+    Attributes:
+        healer (ClassExperience): The healer class
+        mage (ClassExperience): The mage class
+        berserk (ClassExperience): The berserk class
+        archer (ClassExperience): The archer class
+        tank (ClassExperience): The tank class
+    """
+
+    def __init__(self, data: dict[str,dict]) -> None:
+        self.healer: ClassExperience = ClassExperience(data.get("healer", {}))
+        self.mage: ClassExperience = ClassExperience(data.get("mage", {}))
+        self.berserk: ClassExperience = ClassExperience(data.get("berserk", {}))
+        self.archer: ClassExperience = ClassExperience(data.get("archer", {}))
+        self.tank: ClassExperience = ClassExperience(data.get("tank", {}))
+
+    def __str__(self) -> str:
+        return f"Healer {self.healer}, Mage {self.mage}, Berserk {self.berserk}, Archer {self.archer}, Tank {self.tank}"
+        
+        
+        

--- a/hypixel_api_lib/member/dungeons/PlayerClasses.py
+++ b/hypixel_api_lib/member/dungeons/PlayerClasses.py
@@ -1,4 +1,4 @@
-class ClassExperience():
+class ClassExperience:
     """
     Represents a specific dungeon class experience.
 
@@ -11,7 +11,7 @@ class ClassExperience():
     def __str__(self) -> str:
         return f"Experience: {self.experience}"
 
-class PlayerClasses():
+class PlayerClasses:
     """
     All dungeons player classes
 

--- a/hypixel_api_lib/member/dungeons/Treasures.py
+++ b/hypixel_api_lib/member/dungeons/Treasures.py
@@ -1,0 +1,241 @@
+import datetime
+import re
+from hypixel_api_lib.utils import convert_timestamp
+
+def remove_color_codes(text: str) -> str:
+    """
+    Removes Minecraft color codes from a string.
+
+    Args:
+        text (str): The text containing Minecraft color codes.
+
+    Returns:
+        str: The text with color codes removed.
+    """
+    return re.sub(r'§.', '', text)
+
+class RewardItem:
+    """
+    Represents a single reward item from a chest.
+
+    Attributes:
+        raw (str): The original reward string.
+        type (str): The type of reward (e.g., 'rejuvenate', 'ESSENCE:UNDEAD').
+        tier (int or None): The tier or amount associated with the reward.
+    """
+    def __init__(self, data: str) -> None:
+        self.raw: str = data
+        self.type: str = ''
+        self.tier: int | None = None
+        self.parse_reward(data)
+
+    def parse_reward(self, data: str) -> None:
+        """
+        Parses the reward string to extract the type and tier.
+
+        Args:
+            data (str): The reward string to parse.
+        """
+        if ':' in data:
+            # Handle essence or special items like 'ESSENCE:UNDEAD:28'
+            parts = data.split(':')
+            if len(parts) == 3:
+                self.type = f"{parts[0]}:{parts[1]}"
+                try:
+                    self.tier = int(parts[2])
+                except ValueError:
+                    self.tier = None
+        elif '_' in data:
+            # Handle items with tiers like 'rejuvenate_1'
+            parts = data.rsplit('_', 1)
+            if len(parts) == 2:
+                self.type = parts[0]
+                try:
+                    self.tier = int(parts[1])
+                except ValueError:
+                    self.tier = None
+            else:
+                self.type = data
+        else:
+            self.type = data
+
+    def __repr__(self) -> str:
+        return f"<RewardItem type={self.type}, tier={self.tier}>"
+
+class Rewards:
+    """
+    Represents the rewards from a chest.
+
+    Attributes:
+        rewards (list of RewardItem): List of reward items.
+        rolled_rng_meter_randomly (bool): Indicates if the RNG meter was rolled randomly.
+    """
+    def __init__(self, data: dict) -> None:
+        rewards_list: list = data.get('rewards', [])
+        self.rewards: list[RewardItem] = [RewardItem(item) for item in rewards_list]
+        self.rolled_rng_meter_randomly: bool = data.get('rolled_rng_meter_randomly', False)
+
+    def __iter__(self): 
+        return iter(self.rewards)
+
+    def __len__(self) -> int:
+        return len(self.rewards)
+
+    def __getitem__(self, index) -> RewardItem:
+        return self.rewards[index]
+
+class Chest:
+    """
+    Represents a single chest in a dungeon run.
+
+    Attributes:
+        run_id (str): The unique identifier of the run this chest belongs to.
+        chest_id (str): The unique identifier of the chest.
+        treasure_type (str): The type of chest (e.g., 'wood', 'gold').
+        quality (int): The quality score of the chest.
+        shiny_eligible (bool): Indicates if the chest is eligible for shiny rewards.
+        paid (bool): Indicates if the chest was paid for.
+        rerolls (int): The number of rerolls performed on the chest.
+        rewards (Rewards): The rewards contained in the chest.
+    """
+    def __init__(self, data: dict) -> None:
+        self.run_id: str = data.get('run_id', '')
+        self.chest_id: str = data.get('chest_id', '')
+        self.treasure_type: str = data.get('treasure_type', '')
+        self.quality: int = data.get('quality', 0)
+        self.shiny_eligible: bool = data.get('shiny_eligible', False)
+        self.paid: bool = data.get('paid', False)
+        self.rerolls: int = data.get('rerolls', 0)
+        self.rewards: Rewards = Rewards(data.get('rewards', {}))
+
+    def __repr__(self) -> str:
+        return f"<Chest treasure_type={self.treasure_type}, quality={self.quality}>"
+
+class Chests:
+    """
+    Represents a collection of chests.
+
+    Attributes:
+        chests (list of Chest): List of chests from dungeon runs.
+    """
+    def __init__(self, data: list[dict]) -> None:
+        self.chests: list[Chest] = [Chest(chest_data) for chest_data in data]
+
+    def __iter__(self):
+        return iter(self.chests)
+
+    def __len__(self) -> int:
+        return len(self.chests)
+
+    def __getitem__(self, index) -> Chest:
+        return self.chests[index]
+
+class Participant:
+    """
+    Represents a participant in a dungeon run.
+
+    Attributes:
+        player_uuid (str): The UUID of the player.
+        display_name (str): The display name of the player with Minecraft color codes.
+        class_milestone (int): The class milestone achieved by the player.
+    """
+    def __init__(self, data: dict) -> None:
+        self.player_uuid: str = data.get('player_uuid', '')
+        self.display_name: str = data.get('display_name', '')
+        self.class_milestone: int = data.get('class_milestone', 0)
+
+    @property
+    def name(self) -> str:
+        """
+        str: The participant's name without color codes and extra text.
+        """
+        cleaned_name = remove_color_codes(self.display_name)
+        parts = cleaned_name.split(': ')
+        if len(parts) >= 1:
+            return parts[0]
+        return cleaned_name
+
+    @property
+    def player_class(self) -> str:
+        """
+        str: The participant's class (e.g., 'Mage', 'Healer').
+        """
+        cleaned_name = remove_color_codes(self.display_name)
+        parts = cleaned_name.split(': ')
+        if len(parts) >= 2:
+            class_and_level = parts[1]
+            class_parts = class_and_level.split(' (')
+            if len(class_parts) >= 1:
+                return class_parts[0]
+        return ''
+
+    @property
+    def level(self) -> int:
+        """
+        int: The participant's class level.
+        """
+        cleaned_name = remove_color_codes(self.display_name)
+        match = re.search(r'\((\d+)\)', cleaned_name)
+        if match:
+            return int(match.group(1))
+        return 0
+    
+    def __repr__(self) -> str:
+        return f"Participants Name: {self.name}, Class: {self.player_class}, Level: {self.level}"
+
+class Run:
+    """
+    Represents a single dungeon run.
+
+    Attributes:
+        run_id (str): The unique identifier of the run.
+        completion_ts (int): The completion timestamp in milliseconds since epoch.
+        dungeon_type (str): The type of dungeon (e.g., 'master_catacombs').
+        dungeon_tier (int): The tier or floor level of the dungeon.
+        participants (list of Participant): List of participants in the run.
+    """
+    def __init__(self, data: dict) -> None:
+        self.run_id: str = data.get('run_id', '')
+        self.completion_ts: int = data.get('completion_ts', 0)
+        self.dungeon_type: str = data.get('dungeon_type', '')
+        self.dungeon_tier: int = data.get('dungeon_tier', 0)
+        participants_data = data.get('participants', [])
+        self.participants: list[Participant] = [Participant(p) for p in participants_data]
+
+    @property
+    def completion_time(self) -> datetime.datetime:
+        """
+        Returns the completion time as a datetime object.
+        """
+        return convert_timestamp(self.completion_ts)
+
+class Runs:
+    """
+    Represents a collection of dungeon runs.
+
+    Attributes:
+        runs (list of Run): List of dungeon runs.
+    """
+    def __init__(self, data: list[dict]) -> None:
+        self.runs: list[Run] = [Run(run_data) for run_data in data]
+
+    def __iter__(self):
+        return iter(self.runs)
+
+    def __len__(self) -> int:
+        return len(self.runs)
+
+    def __getitem__(self, index) -> Run:
+        return self.runs[index]
+
+class Treasures:
+    """
+    Represents the treasures component, including runs and chests.
+
+    Attributes:
+        runs (Runs): Collection of dungeon runs.
+        chests (Chests): Collection of chests from runs.
+    """
+    def __init__(self, data: dict[str,list[dict]]) -> None:
+        self.runs: Runs = Runs(data.get("runs", []))
+        self.chests: Chests = Chests(data.get("chests", []))

--- a/hypixel_api_lib/member/dungeons/Treasures.py
+++ b/hypixel_api_lib/member/dungeons/Treasures.py
@@ -60,7 +60,11 @@ class RewardItem:
             self.type = data
 
     def __repr__(self) -> str:
-        return f"<RewardItem type={self.type}, tier={self.tier}>"
+        return f"<RewardItem type='{self.type}', tier={self.tier}>"
+
+    def __str__(self) -> str:
+        tier_info = f" Tier {self.tier}" if self.tier is not None else ""
+        return f"{self.type}{tier_info}"
 
 class Rewards:
     """
@@ -71,11 +75,11 @@ class Rewards:
         rolled_rng_meter_randomly (bool): Indicates if the RNG meter was rolled randomly.
     """
     def __init__(self, data: dict) -> None:
-        rewards_list: list = data.get('rewards', [])
+        rewards_list: list[str] = data.get('rewards', [])
         self.rewards: list[RewardItem] = [RewardItem(item) for item in rewards_list]
         self.rolled_rng_meter_randomly: bool = data.get('rolled_rng_meter_randomly', False)
 
-    def __iter__(self): 
+    def __iter__(self):
         return iter(self.rewards)
 
     def __len__(self) -> int:
@@ -83,6 +87,13 @@ class Rewards:
 
     def __getitem__(self, index) -> RewardItem:
         return self.rewards[index]
+
+    def __repr__(self) -> str:
+        return f"<Rewards total_items={len(self.rewards)}, rolled_rng_meter_randomly={self.rolled_rng_meter_randomly}>"
+
+    def __str__(self) -> str:
+        rewards_str = ', '.join(str(reward) for reward in self.rewards)
+        return f"Rewards: [{rewards_str}]"
 
 class Chest:
     """
@@ -109,7 +120,12 @@ class Chest:
         self.rewards: Rewards = Rewards(data.get('rewards', {}))
 
     def __repr__(self) -> str:
-        return f"<Chest treasure_type={self.treasure_type}, quality={self.quality}>"
+        return (f"<Chest id='{self.chest_id}', treasure_type='{self.treasure_type}', "
+                f"quality={self.quality}, paid={self.paid}>")
+
+    def __str__(self) -> str:
+        return (f"Chest ID: {self.chest_id}, Type: {self.treasure_type}, Quality: {self.quality}, "
+                f"Paid: {self.paid}, Rewards: {self.rewards}")
 
 class Chests:
     """
@@ -129,6 +145,12 @@ class Chests:
 
     def __getitem__(self, index) -> Chest:
         return self.chests[index]
+
+    def __repr__(self) -> str:
+        return f"<Chests total={len(self.chests)}>"
+
+    def __str__(self) -> str:
+        return f"Chests Collection with {len(self.chests)} chests"
 
 class Participant:
     """
@@ -179,9 +201,13 @@ class Participant:
         if match:
             return int(match.group(1))
         return 0
-    
+
     def __repr__(self) -> str:
-        return f"Participants Name: {self.name}, Class: {self.player_class}, Level: {self.level}"
+        return (f"<Participant uuid='{self.player_uuid}', name='{self.name}', "
+                f"class='{self.player_class}', level={self.level}>")
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.player_class} Level {self.level})"
 
 class Run:
     """
@@ -209,6 +235,15 @@ class Run:
         """
         return convert_timestamp(self.completion_ts)
 
+    def __repr__(self) -> str:
+        return (f"<Run id='{self.run_id}', dungeon='{self.dungeon_type}', "
+                f"tier={self.dungeon_tier}, completion_time='{self.completion_time}'>")
+
+    def __str__(self) -> str:
+        participants_str = ', '.join(str(p) for p in self.participants)
+        return (f"Run ID: {self.run_id}, Dungeon: {self.dungeon_type} Tier {self.dungeon_tier}, "
+                f"Completed at: {self.completion_time}, Participants: [{participants_str}]")
+
 class Runs:
     """
     Represents a collection of dungeon runs.
@@ -228,6 +263,12 @@ class Runs:
     def __getitem__(self, index) -> Run:
         return self.runs[index]
 
+    def __repr__(self) -> str:
+        return f"<Runs total={len(self.runs)}>"
+
+    def __str__(self) -> str:
+        return f"Runs Collection with {len(self.runs)} runs"
+
 class Treasures:
     """
     Represents the treasures component, including runs and chests.
@@ -239,3 +280,9 @@ class Treasures:
     def __init__(self, data: dict[str,list[dict]]) -> None:
         self.runs: Runs = Runs(data.get("runs", []))
         self.chests: Chests = Chests(data.get("chests", []))
+
+    def __repr__(self) -> str:
+        return f"<Treasures runs={len(self.runs)}, chests={len(self.chests)}>"
+
+    def __str__(self) -> str:
+        return f"Treasures with {len(self.runs)} runs and {len(self.chests)} chests"

--- a/hypixel_api_lib/member/dungeons/__init__.py
+++ b/hypixel_api_lib/member/dungeons/__init__.py
@@ -1,0 +1,1 @@
+from .Dungeons import Dungeons

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -198,7 +198,6 @@ class TestSkyBlockProfiles(unittest.TestCase):
         # Test __str__ method
         profile_str = str(sample_profile)
         self.assertIn("SkyBlockProfile ID: 1234567890abcdef", profile_str)
-        self.assertIn("Members: ['uuid1', 'uuid2']", profile_str)
 
     @patch('requests.get')
     def test_get_profile(self, mock_get):


### PR DESCRIPTION
I have completed a giant subcomponent of the profile members subcomponent. This profile members section is gigantic. I There are giant nested data structures that I have been getting through. Dungeons was the largest one yet and within dungeons there were two also massive data structures I had to break down. Now that it is complete, we can continue to the next higher level component and leave the dungeons part alone now. This section took the most time to break through and was very slow. I Have not created any test cases and I am not really leaving behind any example uses just yet as I think there may be a need for more detailed examples of usage later on. 

The next component here will still be within the sky block profile members section but they should not be as large as dungeons and should not require the same time / depth hopefully.