### PR TITLE
Fixed profile member username field and updated some tests

### DIFF
--- a/hypixel_api_lib/member/ProfileMember.py
+++ b/hypixel_api_lib/member/ProfileMember.py
@@ -80,7 +80,12 @@ class SkyBlockProfileMember:
 
     def __init__(self, uuid: str, data: dict) -> None:
         self.uuid: str = uuid
-        self.username: str = get_username_from_uuid(self.uuid)
+        try:
+            self.username: str = get_username_from_uuid(self.uuid)
+        except ConnectionError:
+            self.username : str = "Unknown"
+        except ValueError:
+            self.username : str = "Unknown"
         self.rift: RiftData = RiftData(data.get('rift', {}))
         self.player_data: PlayerData = PlayerData(data.get('player_data', {}))
         self.glacite_player_data: GlacitePlayerData = GlacitePlayerData(data.get('glacite_player_data', {}))

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -365,7 +365,7 @@ class TestSkyBlockProfileMember(unittest.TestCase):
         Test the string representation of SkyBlockProfileMember.
         """
         member = SkyBlockProfileMember(uuid="uuid1", data=self.sample_member_data)
-        self.assertIn("SkyBlockProfileMember UUID: uuid1", str(member))
+        self.assertIn("SkyBlockProfileMember Username: Unknown, UUID: uuid1", str(member))
 
 class TestPlayerData(unittest.TestCase):
 


### PR DESCRIPTION
The username field in the SkyBlockProfileMember component was having issues with test cases since there we pass an invalid UUID that does not exist and it tries to get a username for it from the Mojang API. We catch the error now and set the username as unknown incase it fails at that step. 

I also updated the test cases in one instance for the profile member __str__ check since I did modify it to show the username now and the UUID instead of just the UUID.